### PR TITLE
Added feature to allow default extensions

### DIFF
--- a/parsefiles.js
+++ b/parsefiles.js
@@ -129,9 +129,9 @@ function parseFilesPUB(source, opts) {
           !lbl.hasOwnProperty('_ext') &&
           lbl.hasOwnProperty('_name') &&
           lbl._name !== '' &&
-          opts.hasOwnProperty('defaultExt')
+          source.hasOwnProperty('defaultExt')
       ) {
-        lbl._ext = opts.defaultExt;
+        lbl._ext = source.defaultExt;
       }
 
       // record ._href

--- a/parsefiles.js
+++ b/parsefiles.js
@@ -124,6 +124,16 @@ function parseFilesPUB(source, opts) {
         }
       }
 
+      // add a default extension, if configured and we're not on the index page
+      if (
+          !lbl.hasOwnProperty('_ext') &&
+          lbl.hasOwnProperty('_name') &&
+          lbl._name !== '' &&
+          opts.hasOwnProperty('defaultExt')
+      ) {
+        lbl._ext = opts.defaultExt;
+      }
+
       // record ._href
       fragment._href = (lbl._path || '') + (lbl._name || '') +
                        (lbl._fragname || '') + (lbl._ext || '');

--- a/test/test-parsefiles.js
+++ b/test/test-parsefiles.js
@@ -197,7 +197,7 @@ function assertNoDiff(t, actual, expected, msg) {
 test('use default extension', function (t) {
   // start from clone of sources without files
   var _sources = [u.omit(sources[0], 'files')];
-  opts.defaultExt = '.html';
+  _sources[0].defaultExt = '.html';
 
   getSources(_sources, opts, function (err, actual) {
     t.error(err);

--- a/test/test-parsefiles.js
+++ b/test/test-parsefiles.js
@@ -193,3 +193,22 @@ function assertNoDiff(t, actual, expected, msg) {
       + (diff.length > maxdiff ? '\n...(truncated)' : ''));
   }
 }
+
+test('use default extension', function (t) {
+  // start from clone of sources without files
+  var _sources = [u.omit(sources[0], 'files')];
+  opts.defaultExt = '.html';
+
+  getSources(_sources, opts, function (err, actual) {
+    t.error(err);
+
+    _sources[0].files = serializeFiles(_sources[0].files); // replace memoized files
+
+    getSources(_sources, opts, function (err, actual2) {
+      t.error(err);
+      t.equal(actual2[2]._href, '/draft-page.html');
+      t.equal(actual2[0]._href, '/')
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a feature to allow a default extension for files, that have no extension set after filtered.

The need for this feature came along, because we wanted to host the generated documentation in another generated documentation and that didn't work without the .html extension for HTML files in links.

This PR adds an option called "defaultExt" which can be set to e.g. ".html" and will set this extension in the _href data for pages, that have no extension (e.g. Markdown-sources). Generated Index files are left out.