### PR TITLE
v3.1

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -30,9 +30,9 @@ module.exports = function helpers(generator) {
   // return html for the current page/fragment or markdown in txt
   hb.registerHelper('html', function(txt, frame) {
     var text = hbp(txt);
-    frame = text ? frame : txt;
     var fragment = text ? { _txt:text, _href:'/#synthetic' } : this;
-    return generator.renderHtml(fragment, renderOpts());
+    var opts = text ? { noWrap:true } : {};
+    return generator.renderHtml(fragment, renderOpts(opts));
   });
 
   // like 'html' without wrapping in an editor div (for menus)
@@ -119,7 +119,9 @@ module.exports = function helpers(generator) {
       refpat = u.escapeRegExp(refpat);
     }
     var re = new RegExp(refpat);
-    return u.filter(generator.fragments, function(fragment) { return re.test(fragment._href); });
+    return u.filter(generator.fragments, function(fragment) {
+      return re.test(fragment._href) && !(opts.production && fragment.nopublish);
+    });
   }
 
   // return frame.data.index mod n (works only inside eachPage or eachFragment)

--- a/helpers.js
+++ b/helpers.js
@@ -90,22 +90,37 @@ module.exports = function helpers(generator) {
       return frame.fn(fragment, { data:localdata });
     });
     return map.join('');
-
-    // lookup multiple fragments via href pattern match
-    // works like resolve with a wildcard
-    // careful using this without #
-    function selectFragments(refpat, context) {
-      refpat = refpat || '#';
-      if (/^#/.test(refpat)) {
-        refpat = '^' + u.escapeRegExp((context._href || '/') + refpat);
-      }
-      else {
-        refpat = u.escapeRegExp(refpat);
-      }
-      var re = new RegExp(refpat);
-      return u.filter(generator.fragments, function(fragment) { return re.test(fragment._href); });
-    }
   });
+
+  // block-helper for fragments matching pattern
+  // fragment pattern should start with #... or /page#...
+  hb.registerHelper('eachFragmentSorted', function(pattern, frame) {
+    var p = hbp(pattern);
+    frame = p ? frame : pattern;
+    var localdata = hb.createFrame(frame.data);
+    var rg = u.sortBy(selectFragments(p, this), 'sort');
+    var map = u.map(rg, function(fragment, index) {
+      localdata.index = index;
+      if (index === rg.length - 1) { localdata.last = true; }
+      return frame.fn(fragment, { data:localdata });
+    });
+    return map.join('');
+  });
+
+  // lookup multiple fragments via href pattern match
+  // works like resolve with a wildcard
+  // careful using this without #
+  function selectFragments(refpat, context) {
+    refpat = refpat || '#';
+    if (/^#/.test(refpat)) {
+      refpat = '^' + u.escapeRegExp((context._href || '/') + refpat);
+    }
+    else {
+      refpat = u.escapeRegExp(refpat);
+    }
+    var re = new RegExp(refpat);
+    return u.filter(generator.fragments, function(fragment) { return re.test(fragment._href); });
+  }
 
   // return frame.data.index mod n (works only inside eachPage or eachFragment)
   hb.registerHelper('mod', function(n, frame) {
@@ -481,6 +496,10 @@ module.exports = function helpers(generator) {
 
   hb.registerHelper('user', function() {
     return (generator.req && generator.req.user) || '';
+  });
+
+  hb.registerHelper('eachUpload', function(frame) {
+    return u.map(generator.req && generator.req.files, frame.fn).join('');
   });
 
 };

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
   "name": "pub-generator",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "markdown/handlebars site generator - runs in node or browser",
   "main": "generator.js",
   "dependencies": {
     "asyncbuilder": "^1.0.8",
     "debug": "^4.1.1",
     "handlebars": "^4.7.6",
-    "marked": "^1.0.0",
-    "marked-forms": "^3.1.0",
-    "pub-resolve-opts": "^1.7.7",
+    "marked": "^1.1.0",
+    "marked-forms": "^4.0.0",
+    "pub-resolve-opts": "^1.7.8",
     "pub-src-http": "^1.1.2",
     "pub-util": "^3.1.0"
   },
   "devDependencies": {
     "deep-diff": "^1.0.2",
-    "eslint": "^6.8.0",
-    "pub-src-fs": "^2.0.10",
-    "tape": "^5.0.0"
+    "eslint": "^7.1.0",
+    "pub-src-fs": "^2.1.0",
+    "tape": "^5.0.1"
   },
   "files": [
     "fragment.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-generator",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "markdown/handlebars site generator - runs in node or browser",
   "main": "generator.js",
   "dependencies": {
@@ -8,7 +8,7 @@
     "debug": "^4.1.1",
     "handlebars": "^4.7.6",
     "marked": "^1.0.0",
-    "marked-forms": "^3.0.0",
+    "marked-forms": "^3.1.0",
     "pub-resolve-opts": "^1.7.7",
     "pub-src-http": "^1.1.2",
     "pub-util": "^3.1.0"

--- a/render.js
+++ b/render.js
@@ -19,7 +19,7 @@ module.exports = function render(generator) {
   var log = opts.log;
 
   marked.use( { renderer: { link: renderLink, image: renderImage } } );
-  marked.use(markedForms());
+  marked.use(markedForms( { allowSpacesInLinks: opts.allowSpacesInLinks } ));
 
   function defaultRenderOpts(docPage) {
     var o = {
@@ -111,7 +111,10 @@ module.exports = function render(generator) {
   function renderLayout(page) {
     var template = layoutTemplate(page);
     var html = renderTemplate(page, template);
-    return '<div data-render-layout="' + esc(template) + '">' + html + '</div>';
+    if (opts.renderPageLayoutOld) {
+      return '<div data-render-layout="' + esc(template) + '">' + html + '</div>';
+    }
+    return '<div data-render-layout="' + esc(template) + '">\n' + html + '\n</div><!--layout-->';
   }
 
   // render a page with a non-layout page-specific template
@@ -120,7 +123,10 @@ module.exports = function render(generator) {
   function renderPage(page) {
     var template = pageTemplate(page);
     var html = renderTemplate(page, template);
-    return '<div data-render-page="' + esc(opts.renderPageOverride ? template : page._href) + '">' + html + '</div>';
+    if (opts.renderPageLayoutOld) {
+      return '<div data-render-page="' + esc(template) + '">' + html + '</div>';
+    }
+    return '<div data-render-page="' + esc(page._href) + '">\n' + html + '\n</div><!--page-->';
   }
 
   // return name of document template for a page

--- a/render.js
+++ b/render.js
@@ -64,6 +64,7 @@ module.exports = function render(generator) {
   generator.rewriteLink     = rewriteLink;     // link rewriter for relPaths etc.
 
   generator.renderPageTree  = renderPageTree;  // render page hierarchy starting at /
+  generator.parseLinks      = parseLinks;      // parse links from item._txt
 
   return;
 
@@ -119,7 +120,7 @@ module.exports = function render(generator) {
   function renderPage(page) {
     var template = pageTemplate(page);
     var html = renderTemplate(page, template);
-    return '<div data-render-page="' + esc(template) + '">' + html + '</div>';
+    return '<div data-render-page="' + esc(page._href) + '">' + html + '</div>';
   }
 
   // return name of document template for a page
@@ -314,5 +315,21 @@ module.exports = function render(generator) {
       });
       return out + '\n</ul>';
     }
+  }
+
+  // parse links from item text as a side effect of rendering with marked
+  // returns an array of hrefs (not fully qualified) usable for lookups in page$
+  // does not use pages.renderer with extended images, forms etc.
+  /*eslint no-unused-vars: "off"*/
+  function parseLinks(item) {
+    if (!item || !item._txt) return;
+    var links = [];
+    var renderer = new marked.Renderer();
+    renderer.link = function(href, title, text) {
+      links.push(href);
+      return ''; // don't care about actual rendered result
+    };
+    marked(item._txt, {renderer:renderer});
+    return links;
   }
 };

--- a/render.js
+++ b/render.js
@@ -120,7 +120,7 @@ module.exports = function render(generator) {
   function renderPage(page) {
     var template = pageTemplate(page);
     var html = renderTemplate(page, template);
-    return '<div data-render-page="' + esc(page._href) + '">' + html + '</div>';
+    return '<div data-render-page="' + esc(opts.renderPageOverride ? template : page._href) + '">' + html + '</div>';
   }
 
   // return name of document template for a page

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -146,7 +146,8 @@ var tests =
     path: '/index.md',
     text: 'hello world\n\n---- /main-layout.hbs ----\n\n<div class="main-layout">test<br>{{{renderPage}}}</div>'
   },
-  result: '<div class="main-layout">test<br><div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
+  result: '<div class="main-layout">test<br><div data-render-page="/">\n' +
+  '<div data-render-html="/"><p>hello world</p>\n</div>\n</div><!--page--></div>'
 },
 
 { name: 'simple page and doc-layout and main-layout templates',
@@ -157,9 +158,9 @@ var tests =
       '\n\n---- /doc-layout.hbs ----\n\n<div class="doc-layout">outer layout<br>{{{renderLayout}}}</div>'
   },
   result: '<div class="doc-layout">outer layout<br>' +
-            '<div data-render-layout="main-layout"><div class="main-layout">inner layout<br>' +
-              '<div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>\n\n' +
-            '</div>' +
+            '<div data-render-layout="main-layout">\n<div class="main-layout">inner layout<br>' +
+              '<div data-render-page="/">\n<div data-render-html="/"><p>hello world</p>\n</div>\n</div><!--page--></div>\n\n' +
+            '\n</div><!--layout-->' +
           '</div>'
 },
 
@@ -169,7 +170,8 @@ var tests =
     path: '/index.md',
     text: 'hello world\n\n---- /doc-layout.hbs ----\n\n<div class="doc-layout">test<br>{{{renderPage}}}</div>'
   },
-  result: '<div class="doc-layout">test<br><div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
+  result: '<div class="doc-layout">test<br><div data-render-page="/">\n' +
+  '<div data-render-html="/"><p>hello world</p>\n</div>\n</div><!--page--></div>'
 },
 
 { name: 'simple page and a doc-layout template with a renderLayout - will break editor',
@@ -178,7 +180,8 @@ var tests =
     path: '/index.md',
     text: 'hello world\n\n---- /doc-layout.hbs ----\n\n<div class="doc-layout">test<br>{{{renderLayout}}}</div>'
   },
-  result: '<div class="doc-layout">test<br><div data-render-layout="default"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
+  result: '<div class="doc-layout">test<br><div data-render-layout="default">\n' +
+  '<div data-render-html="/"><p>hello world</p>\n</div>\n</div><!--layout--></div>'
 },
 
 { name: 'name with spaces etc.',
@@ -229,7 +232,7 @@ tests.reverse().forEach(function run(tst) {
 
   test(tst.name, function(t) {
 
-    var opts = { jquery:0,
+    var opts = { jquery:0, allowSpacesInLinks:true,
       sources: [ { path:'.', files:[tst.file], fragmentDelim:true } ] };
 
     var generator = require('../generator')(opts);

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -146,7 +146,7 @@ var tests =
     path: '/index.md',
     text: 'hello world\n\n---- /main-layout.hbs ----\n\n<div class="main-layout">test<br>{{{renderPage}}}</div>'
   },
-  result: '<div class="main-layout">test<br><div data-render-page="default"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
+  result: '<div class="main-layout">test<br><div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
 },
 
 { name: 'simple page and doc-layout and main-layout templates',
@@ -158,7 +158,7 @@ var tests =
   },
   result: '<div class="doc-layout">outer layout<br>' +
             '<div data-render-layout="main-layout"><div class="main-layout">inner layout<br>' +
-              '<div data-render-page="default"><div data-render-html="/"><p>hello world</p>\n</div></div></div>\n\n' +
+              '<div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>\n\n' +
             '</div>' +
           '</div>'
 },
@@ -169,7 +169,7 @@ var tests =
     path: '/index.md',
     text: 'hello world\n\n---- /doc-layout.hbs ----\n\n<div class="doc-layout">test<br>{{{renderPage}}}</div>'
   },
-  result: '<div class="doc-layout">test<br><div data-render-page="default"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
+  result: '<div class="doc-layout">test<br><div data-render-page="/"><div data-render-html="/"><p>hello world</p>\n</div></div></div>'
 },
 
 { name: 'simple page and a doc-layout template with a renderLayout - will break editor',

--- a/test/test-render.js
+++ b/test/test-render.js
@@ -80,7 +80,7 @@ tests.forEach(function run(tst) {
 
   test(tst.name, function(t) {
 
-    var opts = { jquery:false, sources:[{ path:'.', fragmentDelim:true, files:[tst.file] }] };
+    var opts = { jquery:false, allowSpacesInLinks:true, sources:[{ path:'.', fragmentDelim:true, files:[tst.file] }] };
 
     var generator = require('../generator')(opts);
 


### PR DESCRIPTION
- change html output from renderPage to use `data-render-page="{page._href}"`
  this is more consistent with editor behavior and will be useful for non-SPA page edits 
- new helpers: `eachFragmentSorted` and `eachUpload`
- revert v3.0 removal of generator.parseLinks()

