### PR TITLE
Output filemap

### DIFF
--- a/makepages.js
+++ b/makepages.js
@@ -78,17 +78,22 @@ module.exports = function makepages(fragments, opts) {
     var page = treePages[i];
     var pHref = u.parentHref(page._href, opts.noTrailingSlash);
     var parent = pHref && treePage$[pHref];
+    var irregularParent = false;
     if (pHref && !parent && opts.folderPages) {
       parent = treePage$[pHref] = { _href:pHref, folderPage:true };
       treePages.push(parent); // mutate!
-      // opts.log('WARNING: makepages - synthesized folder page %s for %s', pHref, page._href);
+      opts.log('WARNING: makepages - synthesized parent folder page %s for %s', pHref, page._href);
     }
     else while (pHref && !parent) {
       pHref = u.parentHref(pHref, opts.noTrailingSlash);
       parent = page$[pHref];
+      irregularParent = true;
     }
     if (parent) {
       page._parent = parent;
+      if (irregularParent && opts.parentFolderWarnings) {
+        opts.log('WARNING: makepages - irregular parent folder page %s for %s', pHref, page._href);
+      }
       if (!parent._children) { parent._children = []; }
       var cnt = parent._children.push(page);
       if (cnt > 1) {

--- a/output.js
+++ b/output.js
@@ -53,6 +53,7 @@ module.exports = function output(generator) {
       if (output.match && !output.match(page)) return;
       var file = { page: page, path: page._href };
       if (page['http-header']) { file['http-header'] = page['http-header']; }
+      if (page['noextension']) { file['noextension'] = page['noextension']; }
       files.push(file);
     });
 
@@ -109,7 +110,7 @@ module.exports = function output(generator) {
         debug('index file for %s', file.path);
         file.path = ppath.join(file.path, indexFile);
       }
-      if (!/\.[^/]*$/.test(file.path)) {
+      if (!file.noextension && !/\.[^/]*$/.test(file.path)) {
         file.path = file.path + extension;
       }
     });

--- a/output.js
+++ b/output.js
@@ -50,12 +50,18 @@ module.exports = function output(generator) {
     // pass1: collect files to generate (not /server or /admin or /pub)
     u.each(generator.pages, function(page) {
       if (filterRe.test(page._href)) return;
-      if (output.match && !output.match(page)) return;
       var file = { page: page, path: page._href };
       if (page['http-header']) { file['http-header'] = page['http-header']; }
       if (page['noextension']) { file['noextension'] = page['noextension']; }
       files.push(file);
     });
+
+    if (output.outputAliases && generator.template$.redirect) {
+      u.each(generator.aliase$, function(to, path) {
+        var page = { _href:path, redirect_to:to, nolayout:1, template:'redirect' };
+        files.push({ page:page, path:path });
+      });
+    }
 
     // pass2:
     fixOutputPaths(output, files);
@@ -77,7 +83,11 @@ module.exports = function output(generator) {
         log(err);
         file.text = err;
       }
-      filemap.push( { href:file.page._href, path:file.path } );
+      // insert entry into filemap
+      var fm = { path:file.path };
+      if (file.page._href) { fm.href = file.page._href; }
+      if (file.page.redirect_to) { fm.redirect_to = file.page.redirect_to; }
+      filemap.push( fm );
       delete file.page;
     });
 

--- a/output.js
+++ b/output.js
@@ -7,8 +7,8 @@
 
 var debug = require('debug')('pub:generator:output');
 var u = require('pub-util');
-var path = require('path');
-var ppath = path.posix || path; // in browser path is posix
+var npath = require('path');
+var ppath = npath.posix || npath; // in browser path is posix
 
 module.exports = function output(generator) {
 
@@ -54,12 +54,14 @@ module.exports = function output(generator) {
       if (page['http-header']) { file['http-header'] = page['http-header']; }
       if (page['noextension']) { file['noextension'] = page['noextension']; }
       files.push(file);
+      debug('pages file:', file.path);
     });
 
     if (output.outputAliases && generator.template$.redirect) {
       u.each(generator.aliase$, function(to, path) {
         var page = { _href:path, redirect_to:to, nolayout:1, template:'redirect' };
         files.push({ page:page, path:path });
+        debug('aliases file:', path);
       });
     }
 
@@ -115,9 +117,11 @@ module.exports = function output(generator) {
     var extension = 'extension' in output ? (output.extension || '') : '.html';
     var indexFile = output.indexFile || 'index';
 
+    var i = 0;
     u.each(files, function(file) {
       if (dirMap[file.path]) {
-        debug('index file for %s', file.path);
+        i++;
+        log('index file %d for %s', i, file.path);
         file.path = ppath.join(file.path, indexFile);
       }
       if (!file.noextension && !/\.[^/]*$/.test(file.path)) {

--- a/output.js
+++ b/output.js
@@ -50,6 +50,7 @@ module.exports = function output(generator) {
     // pass1: collect files to generate (not /server or /admin or /pub)
     u.each(generator.pages, function(page) {
       if (filterRe.test(page._href)) return;
+      if (output.match && !output.match(page)) return; // used by tel
       var file = { page: page, path: page._href };
       if (page['http-header']) { file['http-header'] = page['http-header']; }
       if (page['noextension']) { file['noextension'] = page['noextension']; }
@@ -121,7 +122,7 @@ module.exports = function output(generator) {
     u.each(files, function(file) {
       if (dirMap[file.path]) {
         i++;
-        log('index file %d for %s', i, file.path);
+        debug('index file %d for %s', i, file.path);
         file.path = ppath.join(file.path, indexFile);
       }
       if (!file.noextension && !/\.[^/]*$/.test(file.path)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-generator",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "markdown/handlebars site generator - runs in node or browser",
   "main": "generator.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-generator",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "markdown/handlebars site generator - runs in node or browser",
   "main": "generator.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-generator",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "markdown/handlebars site generator - runs in node or browser",
   "main": "generator.js",
   "dependencies": {
@@ -10,12 +10,12 @@
     "marked": "^1.1.1",
     "marked-forms": "^4.0.1",
     "pub-resolve-opts": "^1.9.0",
-    "pub-src-http": "^1.1.3",
-    "pub-util": "^3.1.1"
+    "pub-src-http": "^1.1.4",
+    "pub-util": "^3.2.0"
   },
   "devDependencies": {
     "deep-diff": "^1.0.2",
-    "eslint": "^7.5.0",
+    "eslint": "^7.9.0",
     "pub-src-fs": "^2.1.1",
     "tape": "^5.0.1"
   },

--- a/update.js
+++ b/update.js
@@ -26,7 +26,6 @@ module.exports = function update(generator) {
   generator.clientSave               = u.throttle(clientSave, u.ms(opts.throttleClientSave || '5s'), {leading:true, trailing:true});
   generator.clientSaveUnThrottled    = clientSave;
   generator.serverSave               = serverSave;
-  generator.reloadSources            = reloadSources;
   generator.isFragmentModified       = isFragmentModified;
   generator.revertFragmentState      = revertFragmentState;
 
@@ -297,30 +296,6 @@ module.exports = function update(generator) {
     if (!source._watching || source.src.commit) {
       generator.reload();
     }
-  }
-
-  // trigger reload from source bypassing caches
-  // input = string or array of source names, nothing => all
-  function reloadSources(names) {
-
-    names = u.isArray(names) ? names :
-           names ? [names] :
-           u.keys(opts.source$);
-
-    var results = [];
-
-    u.each(names, function(name) {
-      var source = opts.source$[name];
-      if (source) {
-        source._reloadFromSource = true; // this flag signals cache bypass
-        results.push(name);
-      } else {
-        results.push(log('reloadSources unknown source ' + name));
-      }
-    });
-
-    generator.reload(); // throttled
-    return results;
   }
 
   function notify() {


### PR DESCRIPTION
- async outputPages(err, filemap)
- simplify output.js - no throttling 
- opts.parentFolderWarnings displays warning if page tree is missing folder nodes
- output.outputAliases - use redirect template (not provided) to generate html-based redirects for aliases
- page.noextension - prevents auto .html extension on ouput
- remove generator.reloadSources() from update.js - editor apis temporarily externalized
